### PR TITLE
fix typo

### DIFF
--- a/asm.md
+++ b/asm.md
@@ -349,7 +349,7 @@ which generates the following assembler output as seen by objdump:
 
 ```
 0000000000000000 <_start>:
-   0:	00032537          	lui     a0,0x32
+   0:	00032537          	lui     a0,0x33
    4:	bfb50513          	addi    a0,a0,-1029
    8:	00e51513          	slli    a0,a0,0xe
    c:	abe50513          	addi    a0,a0,-1346


### PR DESCRIPTION
I have used riscv64-unknown-elf-gcc to test 'li a0,0xcafebabe' ,and then it output 'lui a0,0x33' .I also verified its correctness.